### PR TITLE
[WIP] Build with clickable for 16.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 100balls.qmlproject.user*
 100balls.pro.user*
+.clickable/*
+build/*

--- a/100balls/100balls.apparmor
+++ b/100balls/100balls.apparmor
@@ -1,4 +1,4 @@
 {
-    "policy_version": 1.2,
+    "policy_version": 16.04,
     "policy_groups": []
 }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Then you can close this repository, and launch the game executing
 in the root of the project
 
 ### On Ubuntu Phone
+This app can be installed from the [OpenStore](https://open-store.io/app/com.ubuntu.developer.rpadovani.100balls). 
 
-The app is free, you can find it on the Ubuntu Store
+To build the click package, install [clickable](https://github.com/bhdouglass/clickable). Simply run `clickable` from the app directory. See [clickable documentation](http://clickable.bhdouglass.com/) for details. 
 
 ## Contribution
 
@@ -27,7 +28,7 @@ to Riccardo or ping rpadovani on #ubuntu-app-devel on Freenode :-)
 
 ## Thanks
 
-This game won't be possible without help of these developers:
+This game wouldn't be possible without help of these developers:
 
 - Alan Pope
 - Ken VanDine

--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,5 @@
+{
+  "template": "qmake",
+  "sdk": "ubuntu-sdk-16.04",
+  "dependencies": ["qtdeclarative5-bacon2d1.0"]
+}

--- a/manifest/manifest.json.in
+++ b/manifest/manifest.json.in
@@ -11,5 +11,5 @@
     },
     "version": "0.4.1",
     "maintainer": "Riccardo Padovani <riccardo@rpadovani.com>",
-    "framework": "ubuntu-sdk-14.10"
+    "framework": "ubuntu-sdk-16.04"
 }


### PR DESCRIPTION
- [x] Adapt Manifest and AppArmour
- [x] Add clickable.json including Bacon2D dependency
- [ ] Fix white screen issue, see log file:
```
Loading module: 'libubuntu_application_api_touch_mirclient.so.3.0.0'
qrc:///main.qml:100:5: Type GameScene unavailable
qrc:///components/GameScene.qml:29:14: Invalid property assignment: "running" is a read-only property
library "/vendor/lib/egl/libGLESv2S3D_adreno.so" not found
```